### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 ########################################
 
-LoRaWANClient KEYWORD1
+LoRaWANClient	KEYWORD1
 ########################################
 # Methods and Functions (KEYWORD2)
 ########################################
-connect KEYWORD2
-sendCmd  KEYWORD2
-sendData  KEYWORD2
+connect	KEYWORD2
+sendCmd	KEYWORD2
+sendData	KEYWORD2
 
 ########################################
 # Constants (LITERAL1)
 ########################################
-LoRa_RX_PIN KEYWORD3
-LoRa_TX_PIN KEYWORD3
-INIT_WAIT_TIME  KEYWORD3
-SERIAL_WAIT_TIME  KEYWORD3
-NETWORK_WAIT_TIME KEYWORD3
-JOIN_RETRY_MAX  KEYWORD3
+LoRa_RX_PIN	KEYWORD3
+LoRa_TX_PIN	KEYWORD3
+INIT_WAIT_TIME	KEYWORD3
+SERIAL_WAIT_TIME	KEYWORD3
+NETWORK_WAIT_TIME	KEYWORD3
+JOIN_RETRY_MAX	KEYWORD3


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords